### PR TITLE
Add ARM MacOS compilation and fix warnings/buffer overflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+Linux_Build/
+MD_Dumper
+MD_Dumper_GUI
+MacOS_Build/
+Windows_Build/
+dump_smd.bin

--- a/Build_Linux.sh
+++ b/Build_Linux.sh
@@ -2,7 +2,7 @@
 
 gcc main.c -DSDLGUI -I/usr/include/SDL2 -I/usr/include/libusb-1.0 -L/usr/lib -lSDL2main -lSDL2_image -lSDL2 -lusb-1.0 -o MD_Dumper_GUI
 gcc main.c -I/usr/include/libusb-1.0 -L/usr/lib -lusb-1.0 -o MD_Dumper
-mkdir Linux_Build
+mkdir -p Linux_Build
 cp -dR Informations.txt ./Linux_Build
 cp *.csv ./Linux_Build/
 cp MD_Dumper ./Linux_Build/

--- a/Build_MacOS.sh
+++ b/Build_MacOS.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+clang main.c -DSDLGUI -I/opt/homebrew/include/SDL2 -I/opt/homebrew/include/libusb-1.0 -L/opt/homebrew/lib -lSDL2main -lSDL2_image -lSDL2 -lusb-1.0 -o MD_Dumper_GUI
+clang main.c -I/opt/homebrew/include/libusb-1.0 -L/opt/homebrew/lib -lusb-1.0 -o MD_Dumper
+mkdir -p MacOS_Build
+cp Informations.txt ./MacOS_Build
+cp *.csv ./MacOS_Build/
+cp MD_Dumper ./MacOS_Build/
+cp MD_Dumper_GUI ./MacOS_Build/
+cp -R images ./MacOS_Build/

--- a/md_dumper_read.h
+++ b/md_dumper_read.h
@@ -39,7 +39,7 @@ int Read_ROM_Auto(void)
 
     if ( sms_mode == 0 && Hardwaretype == 0 ) // Dump Megadrive cartridge in no mapper mode
     {
-        printf("Rom Size : %ld Ko \n",game_size);
+        printf("Rom Size : %d Ko\n",game_size);
         game_size = game_size*1024;
         BufferROM = (unsigned char*)malloc(game_size);
         // Cleaning ROM Buffer
@@ -469,7 +469,7 @@ int Read_ROM_Manual(void)
     }
 
     printf("\n");
-    printf("Rom Size (Manual Mode) : %ld Ko \n",game_size/1024);
+    printf("Rom Size (Manual Mode) : %d Ko\n",game_size/1024);
     BufferROM = (unsigned char*)malloc(game_size);
     // Cleaning ROM Buffer
     for (i=0; i<game_size; i++)
@@ -630,14 +630,14 @@ int Read_ROM_Bankswitch(void)
             Index_chksm = i;
             printf("\n");
             printf("Found game in extra CSV Gamelist  \n");
-            printf("Position in csv table %d \n",i);
+            printf("Position in csv table %lu\n",i);
             strncpy(txt_csv_game_size,chksm_text_values[i]+5,4);
             txt_csv_game_size[4] = '\0'; // Null-terminate the output string
             //printf(" txt game size : %s \n",txt_csv_game_size);
             csv_game_size = (unsigned char)strtol(txt_csv_game_size, NULL, 10);
             //printf(" CSV Game Size  %d \n",csv_game_size);
             game_size=1024*csv_game_size;
-            printf("ROM Size from CSV is %ld Ko \n",game_size);
+            printf("ROM Size from CSV is %d Ko\n",game_size);
         }
     }
     NumberOfBank = game_size/512;
@@ -785,7 +785,7 @@ int Read_RAM_Auto(void)
     return 0;
 }
 
-int Read_RAM_Bankswitch(void)
+void Read_RAM_Bankswitch(void)
 {
     printf("Read Mode Bankswitch: Read Save Data\n");
     printf("TODO !...\n");
@@ -795,7 +795,7 @@ int Read_RAM_Manual(void)
 {
     printf("Read Mode Manual : Read Save Data\n");
     printf("Reading in progress...\n");
-    printf("%ld",dump_sram_size_opts);
+    printf("%d",dump_sram_size_opts);
     timer_start();
     if(dump_sram_size_opts==0)
         save_size = 8192;

--- a/md_dumper_write.h
+++ b/md_dumper_write.h
@@ -95,11 +95,11 @@ int Erase_Flash()
 			{
 				Index_chksm = i;
 				printf("Found chip in CSV Flashlist ! \n");
-				printf("Position in csv table %d \n",i);
+				printf("Position in csv table %lu\n",i);
 
 				// Flash Size
 				strncpy(txt_csv_flash_size,chipid_text_values[i]+5,3);
-				txt_csv_flash_size[4] = '\0'; // Null-terminate the output string
+				txt_csv_flash_size[3] = '\0'; // Null-terminate the output string
 				//printf("Txt flash size : %s \n",txt_csv_flash_size);
 				csv_flash_size = (unsigned char)strtol(txt_csv_flash_size, NULL, 10);
 				//printf("CSV Flash Size  %d \n",csv_flash_size);
@@ -122,7 +122,7 @@ int Erase_Flash()
 
 				// Chip Name
 				strncpy(txt_csv_flash_name,chipid_text_values[i]+15,11);
-				txt_csv_flash_name[12] = '\0'; // Null-terminate the output string
+				txt_csv_flash_name[11] = '\0'; // Null-terminate the output string
 				//printf("Flash Device Reference : %s \n",txt_csv_flash_name);
 
 				// Voltage
@@ -134,15 +134,15 @@ int Erase_Flash()
 
 				// Manufacturer
 				strncpy(txt_csv_man_name,chipid_text_values[i]+30,18);
-				txt_csv_man_name[19] = '\0'; // Null-terminate the output string
+				txt_csv_man_name[18] = '\0'; // Null-terminate the output string
 				//printf("Chip Manufacturer : %s \n",txt_csv_man_name);
 
-				printf("Memory : %s \n",txt_csv_flash_name);
-				printf("Capacity %ld Ko \n",flash_size);
-				printf("Chip Manufacturer : %s \n",txt_csv_man_name);
-				printf("Chip Voltage %ld V \n",csv_voltage);
-				printf("CSV Erase Algo  %d \n",csv_erase_algo);
-				printf("CSV Write Algo %d \n",csv_write_algo);
+				printf("Memory : %s\n",txt_csv_flash_name);
+				printf("Capacity %ld Ko\n",flash_size);
+				printf("Chip Manufacturer : %s\n",txt_csv_man_name);
+				printf("Chip Voltage %hhu V\n",csv_voltage);
+				printf("CSV Erase Algo  %d\n",csv_erase_algo);
+				printf("CSV Write Algo %d\n",csv_write_algo);
 			}
 		}
 
@@ -297,7 +297,7 @@ int Write_Flash(void)
 			if(new!=old)
 			{
 				old=new;
-				printf("WRITE SMD flash in progress: %ld%%", new);
+				printf("WRITE SMD flash in progress: %d", new);
 				fflush(stdout);
 			}
 		}
@@ -360,12 +360,12 @@ int Write_Flash(void)
 			if ( flash_id == csv_deviceID  )
 			{
 				Index_chksm = i;
-				printf("Found chip in CSV Flashlist ! \n");
-				printf("Position in csv table %d \n",i);
+				printf("Found chip in CSV Flashlist !\n");
+				printf("Position in csv table %lu\n",i);
 
 				// Flash Size
 				strncpy(txt_csv_flash_size,chipid_text_values[i]+5,3);
-				txt_csv_flash_size[4] = '\0'; // Null-terminate the output string
+				txt_csv_flash_size[3] = '\0'; // Null-terminate the output string
 				//printf("Txt flash size : %s \n",txt_csv_flash_size);
 				csv_flash_size = (unsigned char)strtol(txt_csv_flash_size, NULL, 10);
 				//printf("CSV Flash Size  %d \n",csv_flash_size);
@@ -388,7 +388,7 @@ int Write_Flash(void)
 
 				// Chip Name
 				strncpy(txt_csv_flash_name,chipid_text_values[i]+15,11);
-				txt_csv_flash_name[12] = '\0'; // Null-terminate the output string
+				txt_csv_flash_name[11] = '\0'; // Null-terminate the output string
 				//printf("Flash Device Reference : %s \n",txt_csv_flash_name);
 
 				// Voltage
@@ -400,13 +400,13 @@ int Write_Flash(void)
 
 				// Manufacturer
 				strncpy(txt_csv_man_name,chipid_text_values[i]+30,18);
-				txt_csv_man_name[19] = '\0'; // Null-terminate the output string
+				txt_csv_man_name[18] = '\0'; // Null-terminate the output string
 				//printf("Chip Manufacturer : %s \n",txt_csv_man_name);
 
 				printf("Memory : %s \n",txt_csv_flash_name);
 				printf("Capacity %ld Ko \n",flash_size);
 				printf("Chip Manufacturer : %s \n",txt_csv_man_name);
-				printf("Chip Voltage %ld V \n",csv_voltage);
+				printf("Chip Voltage %hhu V \n",csv_voltage);
 				printf("CSV Erase Algo  %d \n",csv_erase_algo);
 				printf("CSV Write Algo %d \n",csv_write_algo);
 			}
@@ -484,7 +484,7 @@ int Write_Flash(void)
 				if(new!=old)
 				{
 					old=new;
-					printf("WRITE SMD flash in progress: %ld%%", new);
+					printf("WRITE SMD flash in progress: %d", new);
 					fflush(stdout);
 				}
 			}
@@ -566,7 +566,7 @@ int Write_Flash(void)
 				if(new!=old)
 				{
 					old=new;
-					printf("Flash ROM in progress: %ld%%", new);
+					printf("Flash ROM in progress: %d", new);
 					fflush(stdout);
 				}
 			}
@@ -595,12 +595,12 @@ int Write_Flash(void)
 
 			// Calculate Number of Bank
 
-			 printf("Game Size is %ld Ko \n",game_size/1024);
-			 NumberOfBank = game_size/(1024*512);
-             printf("Number of Banks is %d \n",NumberOfBank);
-             printf("Bank Size is 512 Ko  \n");
+			printf("Game Size is %d Ko\n", game_size/1024);
+			NumberOfBank = game_size/(1024*512);
+			printf("Number of Banks is %d\n", NumberOfBank);
+			printf("Bank Size is 512 Ko\n");
 
-			 // Write first part of the ROM as fast as possible
+			// Write first part of the ROM as fast as possible
 
             printf("Write bank O-7 to $000000 - $3FFFFF \n");
             printf("Please wait ...\n");
@@ -633,7 +633,7 @@ int Write_Flash(void)
 				if(new!=old)
 				{
 					old=new;
-					printf("\nWRITE SMD flash in progress: %ld%%", new);
+					printf("\nWRITE SMD flash in progress: %d", new);
 					fflush(stdout);
 				}
 			}
@@ -710,7 +710,7 @@ int Write_Flash(void)
 				if(new!=old)
 				{
 					old=new;
-					printf("\nWRITE SMD flash in progress: %ld%%", new);
+					printf("\nWRITE SMD flash in progress: %d", new);
 					fflush(stdout);
 				}
 			}


### PR DESCRIPTION
Added Apple M chips (ARM) MacOS compilation support.

Originally MacOS build was crashing due to a buffer overflow from `dump_name` being 32 bytes long but 48 bytes being written to it, so the buffer was bumped to 64 to allow MacOS to properly run.
I assume this is because of ARM's more strict out of bounds memory accessing as previously the code was not crashing on my Linux PC.

I also went ahead and fixed most of the issues reported by clang, especially some out of bounds index accesses and incorrect printf format specifiers. Some of them were being reported by GCC as well.